### PR TITLE
Escape dynamic OCR regex and add LaTeX tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node src/util/regex.test.js"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.53.0",

--- a/frontend/src/util/regex.test.js
+++ b/frontend/src/util/regex.test.js
@@ -1,0 +1,15 @@
+import assert from 'assert';
+import { escapeRegex, safeRegExp } from './regex.js';
+
+const sample = '\\int_0^1 \\sqrt{x} dx';
+
+// escapeRegex should escape special characters
+const escaped = escapeRegex(sample);
+const manualRegex = new RegExp(escaped);
+assert(manualRegex.test(sample));
+
+// safeRegExp should return a usable RegExp object
+const safe = safeRegExp(sample);
+assert(safe && safe.test(sample));
+
+console.log('regex util tests passed');


### PR DESCRIPTION
## Summary
- escape regex indicators in should_use_svg and gate short-content logic on confidence
- sanitize subject, question type, and topic matching with re.escape
- add LaTeX-heavy tests for backend OCR and frontend regex utilities

## Testing
- `export SUPABASE_URL=http://example.com && export SUPABASE_KEY=dummy && pytest`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896b2fb8dc48326990c84233e39c609