### PR TITLE
feat: add chat interface components

### DIFF
--- a/frontend/src/components/Chat.jsx
+++ b/frontend/src/components/Chat.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import SuggestionCard from './SuggestionCard';
+import MessageBubble from './MessageBubble';
+import InputBar from './InputBar';
+import { useAuth } from '../context/AuthProvider';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:8000';
+
+export default function Chat() {
+  const { session } = useAuth();
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+
+  const sendMessage = async (text, file) => {
+    if (!text && !file) return;
+    setMessages(prev => [...prev, { role: 'user', content: text }]);
+    try {
+      const authHeaders = {};
+      if (session && session !== 'guest') {
+        authHeaders['Authorization'] = `Bearer ${session.access_token}`;
+      }
+
+      let res;
+      if (file) {
+        const formData = new FormData();
+        formData.append('file', file);
+        res = await fetch(`${API_BASE_URL}/upload`, {
+          method: 'POST',
+          headers: authHeaders,
+          body: formData
+        });
+      } else {
+        res = await fetch(`${API_BASE_URL}/solve`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeaders },
+          body: JSON.stringify({ prompt: text })
+        });
+      }
+      if (!res.ok) throw new Error('Network response was not ok');
+      const data = await res.json();
+      const answer = data.answer || data.result || data.response || 'No response';
+      setMessages(prev => [...prev, { role: 'assistant', content: answer }]);
+    } catch (err) {
+      setMessages(prev => [...prev, { role: 'assistant', content: 'Failed to fetch answer.' }]);
+    }
+  };
+
+  const suggestions = [
+    'Differentiate x^2 e^x',
+    'What is the derivative of sin(x)?',
+    'Solve for x: 2x + 3 = 7',
+    'Explain the chain rule in calculus'
+  ];
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="p-4 border-b border-white/10 text-lg font-bold">Chat</header>
+      <div className="p-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+        {suggestions.map((s) => (
+          <SuggestionCard key={s} prompt={s} onSelect={setInput} />
+        ))}
+      </div>
+      <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
+        {messages.map((m, i) => (
+          <MessageBubble key={i} role={m.role}>
+            {m.content}
+          </MessageBubble>
+        ))}
+      </div>
+      <InputBar value={input} onChange={setInput} onSend={sendMessage} />
+    </div>
+  );
+}

--- a/frontend/src/components/InputBar.jsx
+++ b/frontend/src/components/InputBar.jsx
@@ -1,0 +1,61 @@
+import React, { useRef, useState } from 'react';
+import { Paperclip, Mic, Camera, Send } from 'lucide-react';
+
+export default function InputBar({ value, onChange, onSend }) {
+  const fileRef = useRef(null);
+  const [file, setFile] = useState(null);
+
+  const handleSend = () => {
+    if (!value && !file) return;
+    onSend(value, file);
+    onChange('');
+    setFile(null);
+    if (fileRef.current) fileRef.current.value = '';
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="flex items-end gap-2 p-4 border-t border-white/10">
+      <button
+        type="button"
+        onClick={() => fileRef.current && fileRef.current.click()}
+        className="p-2 rounded hover:bg-white/20 transition"
+      >
+        <Paperclip size={20} />
+      </button>
+      <button type="button" className="p-2 rounded hover:bg-white/20 transition">
+        <Mic size={20} />
+      </button>
+      <button type="button" className="p-2 rounded hover:bg-white/20 transition">
+        <Camera size={20} />
+      </button>
+      <textarea
+        className="flex-1 resize-none bg-transparent outline-none text-white p-2"
+        rows={1}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Ask something..."
+      />
+      <button
+        type="button"
+        onClick={handleSend}
+        className="p-2 rounded bg-gradient-to-r from-electric-cyan to-hyper-violet text-white"
+      >
+        <Send size={20} />
+      </button>
+      <input
+        type="file"
+        ref={fileRef}
+        onChange={(e) => setFile(e.target.files[0])}
+        className="hidden"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/MessageBubble.jsx
+++ b/frontend/src/components/MessageBubble.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function MessageBubble({ role = 'user', children }) {
+  const isUser = role === 'user';
+  const base = 'max-w-[75%] px-4 py-2 rounded-lg text-sm whitespace-pre-wrap';
+  const userStyles = 'self-end bg-gradient-to-r from-electric-cyan to-hyper-violet text-white';
+  const aiStyles = 'self-start bg-white/10 text-white';
+  return <div className={`${base} ${isUser ? userStyles : aiStyles}`}>{children}</div>;
+}

--- a/frontend/src/components/SuggestionCard.jsx
+++ b/frontend/src/components/SuggestionCard.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function SuggestionCard({ avatar, prompt, onSelect }) {
+  return (
+    <div
+      className="flex items-center gap-3 p-4 bg-white/10 rounded-lg cursor-pointer hover:bg-white/20 transition"
+      onClick={() => onSelect(prompt)}
+    >
+      {avatar && (
+        <div className="w-10 h-10 rounded-full overflow-hidden flex-shrink-0">
+          {avatar}
+        </div>
+      )}
+      <p className="text-sm text-white/90">{prompt}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add chat component with suggestion cards, message list, and send handler hitting /solve and /upload
- introduce message bubble, suggestion card, and input bar components styled with Tailwind
- hook into auth context to include bearer token when sending messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bff024d84832680067b0d57d7b830