### PR TITLE
Add avatar context and settings popover

### DIFF
--- a/frontend/src/components/Avatar.jsx
+++ b/frontend/src/components/Avatar.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useAvatar } from '../context/AvatarProvider.jsx';
+
+const PACKS = {
+  classic: '#3b82f6',
+  animals: '#10b981',
+};
+
+const VARIANTS = {
+  math: '#f59e0b',
+  science: '#14b8a6',
+  language: '#ef4444',
+};
+
+const SEASONS = {
+  default: null,
+  winter: '#e0f2fe',
+  summer: '#fde68a',
+};
+
+export default function Avatar({ pack: packProp, variant: variantProp, season: seasonProp, size = 64 }) {
+  const ctx = useAvatar();
+  const pack = packProp || ctx.pack;
+  const variant = variantProp || ctx.variant;
+  const season = seasonProp || ctx.season;
+
+  const base = PACKS[pack] || PACKS.classic;
+  const accent = VARIANTS[variant] || VARIANTS.math;
+  const overlay = SEASONS[season];
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      xmlns="http://www.w3.org/2000/svg"
+      className="inline-block"
+    >
+      <circle cx="32" cy="32" r="30" fill={base} />
+      <circle cx="22" cy="26" r="5" fill="#fff" />
+      <circle cx="42" cy="26" r="5" fill="#fff" />
+      <path
+        d="M22 40c4 4 16 4 20 0"
+        stroke={accent}
+        strokeWidth="4"
+        strokeLinecap="round"
+        fill="none"
+      />
+      {overlay && <circle cx="32" cy="32" r="30" fill={overlay} opacity="0.3" />}
+    </svg>
+  );
+}

--- a/frontend/src/components/SettingsPopover.jsx
+++ b/frontend/src/components/SettingsPopover.jsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { useAvatar } from '../context/AvatarProvider.jsx';
+
+const PACKS = ['classic', 'animals'];
+const VARIANTS = ['math', 'science', 'language'];
+const SEASONS = ['default', 'winter', 'summer'];
+
+export default function SettingsPopover() {
+  const { pack, variant, season, setPack, setVariant, setSeason } = useAvatar();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative inline-block text-left">
+      <button
+        className="px-3 py-2 bg-white/10 rounded-md text-white text-sm hover:bg-white/20"
+        onClick={() => setOpen(!open)}
+      >
+        Avatar Settings
+      </button>
+      {open && (
+        <div className="absolute z-10 right-0 mt-2 w-56 rounded-md shadow-lg bg-white/90 text-gray-900">
+          <div className="p-4 space-y-4">
+            <div>
+              <h4 className="text-xs font-semibold uppercase text-gray-500 mb-2">Pack</h4>
+              <div className="flex flex-wrap gap-2">
+                {PACKS.map(p => (
+                  <button
+                    key={p}
+                    onClick={() => setPack(p)}
+                    className={`px-2 py-1 rounded text-sm ${p === pack ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-900'}`}
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <h4 className="text-xs font-semibold uppercase text-gray-500 mb-2">Season</h4>
+              <div className="flex flex-wrap gap-2">
+                {SEASONS.map(s => (
+                  <button
+                    key={s}
+                    onClick={() => setSeason(s)}
+                    className={`px-2 py-1 rounded text-sm ${s === season ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-900'}`}
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <h4 className="text-xs font-semibold uppercase text-gray-500 mb-2">Variant</h4>
+              <div className="flex flex-wrap gap-2">
+                {VARIANTS.map(v => (
+                  <button
+                    key={v}
+                    onClick={() => setVariant(v)}
+                    className={`px-2 py-1 rounded text-sm ${v === variant ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-900'}`}
+                  >
+                    {v}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/context/AvatarProvider.jsx
+++ b/frontend/src/context/AvatarProvider.jsx
@@ -1,0 +1,23 @@
+import { createContext, useContext, useState } from 'react';
+
+const AvatarContext = createContext(null);
+
+export const AvatarProvider = ({ children }) => {
+  const [pack, setPack] = useState('classic');
+  const [variant, setVariant] = useState('math');
+  const [season, setSeason] = useState('default');
+
+  return (
+    <AvatarContext.Provider value={{ pack, setPack, variant, setVariant, season, setSeason }}>
+      {children}
+    </AvatarContext.Provider>
+  );
+};
+
+export const useAvatar = () => {
+  const context = useContext(AvatarContext);
+  if (!context) {
+    throw new Error('useAvatar must be used within an AvatarProvider');
+  }
+  return context;
+};

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,16 +2,19 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { AvatarProvider } from './context/AvatarProvider.jsx'
 
 function Root() {
   return (
-    <div className="grid h-screen p-4 gap-4 grid-cols-1 md:grid-cols-[280px,1fr] lg:grid-cols-[280px,1fr,320px]">
-      <aside className="hidden md:block" />
-      <main className="min-w-0">
-        <App />
-      </main>
-      <aside className="hidden lg:block" />
-    </div>
+    <AvatarProvider>
+      <div className="grid h-screen p-4 gap-4 grid-cols-1 md:grid-cols-[280px,1fr] lg:grid-cols-[280px,1fr,320px]">
+        <aside className="hidden md:block" />
+        <main className="min-w-0">
+          <App />
+        </main>
+        <aside className="hidden lg:block" />
+      </div>
+    </AvatarProvider>
   )
 }
 


### PR DESCRIPTION
## Summary
- add avatar component that renders SVG based on selected pack, variant and season
- introduce AvatarProvider context to share avatar selections across the app
- create SettingsPopover for toggling avatar packs, seasons and variants and wrap app with provider

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c0494b4488326bbf6412f21e52030